### PR TITLE
Prevent linker errors by protecting hsvToRgb(...) from being garbage …

### DIFF
--- a/src/Kaleidoscope/LED-Fire.h
+++ b/src/Kaleidoscope/LED-Fire.h
@@ -29,7 +29,17 @@ namespace kaleidoscope { namespace plugin {
 class FireEffect : public LEDMode {
  public:
   FireEffect(void) {};
-
+  
+  EventHandlerResult onSetup() {
+     
+      // This dummy call protects the hsvToRgb function from being 
+      // garbage collected under certain circumstances.
+      //
+      hsvToRgb(0, 0, 0);
+      
+      return EventHandlerResult::OK;
+  }
+  
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t key_state);
 
   // ms before idle animation starts after last keypress


### PR DESCRIPTION
…collected

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>